### PR TITLE
Hide own account phone number from chatter role

### DIFF
--- a/src/components/common/profile/ChatExtra.tsx
+++ b/src/components/common/profile/ChatExtra.tsx
@@ -17,6 +17,7 @@ import { type BotAppPermissions, ManagementScreens } from '../../../types';
 import {
   FRAGMENT_PHONE_CODE, FRAGMENT_PHONE_LENGTH, MUTE_INDEFINITE_TIMESTAMP, UNMUTE_TIMESTAMP,
 } from '../../../config';
+import { CAN_SEE_PHONE_NUMBERS } from '../../../util/crmchat';
 import {
   buildStaticMapHash,
   getChatLink,
@@ -408,7 +409,7 @@ const ChatExtra = ({
           />
         </div>
       )}
-      {Boolean(formattedNumber?.length) && (
+      {(CAN_SEE_PHONE_NUMBERS || !isSelf) && Boolean(formattedNumber?.length) && (
         <ListItem
           icon="phone"
           className={styles.phone}

--- a/src/util/crmchat.ts
+++ b/src/util/crmchat.ts
@@ -242,3 +242,4 @@ export const CAN_ACCESS_SETTINGS = !isChatter;
 export const CAN_ACCESS_SERVICE_NOTIFICATIONS = !isChatter;
 export const CAN_BLOCK_CONTACT = !isChatter;
 export const CAN_MUTE_CHAT = !isChatter;
+export const CAN_SEE_PHONE_NUMBERS = !isChatter;


### PR DESCRIPTION
Chatters can no longer see their own Telegram account's phone number in the profile view. Other contacts' phone numbers remain visible.